### PR TITLE
fix: renamed client and server args stuff with different prefixes

### DIFF
--- a/src/client/args.c
+++ b/src/client/args.c
@@ -15,9 +15,9 @@
 // before ebery return statement to free the declared string as doing it
 // manually would result in too much boilerplate and less readable code
 #define deferred_free_str __attribute__((cleanup(defer_free_str)))
-void defer_free_str(char **thing) { free(*thing); }
+static void defer_free_str(char **thing) { free(*thing); }
 
-PAResult parse_args(const int argc, char *argv[], ClientConfig *out) {
+CPAResult client_parse_args(const int argc, char *argv[], ClientConfig *out) {
   opterr = 0; // disable default error message
 
   // setup temp variables with invalid data so it can be detected later if
@@ -159,7 +159,7 @@ PAResult parse_args(const int argc, char *argv[], ClientConfig *out) {
   return OK;
 }
 
-void print_usage(const char *program_name) {
+void client_print_usage(const char *program_name) {
   fprintf(stderr,
           "Usage:\n"
           "  %s -f <input> -k <key> -t <threads> -a <server ip> -p <server "
@@ -175,7 +175,7 @@ void print_usage(const char *program_name) {
           program_name);
 }
 
-char *pa_result_to_string(const PAResult result) {
+char *client_pa_result_to_string(const CPAResult result) {
   switch (result) {
   case OK:
     return "success";

--- a/src/client/args.h
+++ b/src/client/args.h
@@ -37,8 +37,8 @@ typedef enum {
   MALFORMED_SERVER_PORT,
   MULTIPLE_SERVER_PORT,
 
-} PAResult;
+} CPAResult;
 
-PAResult parse_args(const int argc, char *argv[], ClientConfig *out);
-char *pa_result_to_string(PAResult result);
-void print_usage(const char *program_name);
+CPAResult client_parse_args(const int argc, char *argv[], ClientConfig *out);
+char *client_pa_result_to_string(CPAResult result);
+void client_print_usage(const char *program_name);

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -4,16 +4,16 @@
 
 int main(int argc, char *argv[]) {
   ClientConfig config = {0};
-  PAResult result = parse_args(argc, argv, &config);
+  PAResult result = client_parse_args(argc, argv, &config);
 
   if (result == ONLY_HELP) {
-    print_usage(argv[0]);
+    client_print_usage(argv[0]);
     return 0;
   }
 
   if (result != OK) {
-    fprintf(stderr, "%s\n", pa_result_to_string(result));
-    print_usage(argv[0]);
+    fprintf(stderr, "%s\n", client_pa_result_to_string(result));
+    client_print_usage(argv[0]);
     return 1;
   }
 

--- a/src/server/args.c
+++ b/src/server/args.c
@@ -17,11 +17,11 @@
 // before ebery return statement to free the declared string as doing it
 // manually would result in too much boilerplate and less readable code
 #define deferred_free_str __attribute__((cleanup(defer_free_str)))
-void defer_free_str(char **thing) { free(*thing); }
+static void defer_free_str(char **thing) { free(*thing); }
 
-bool is_valid_prefix(const char *prefix);
+static bool is_valid_prefix(const char *prefix);
 
-PAResult parse_args(const int argc, char *argv[], ServerConfig *out) {
+SPAResult server_parse_args(const int argc, char *argv[], ServerConfig *out) {
   opterr = 0; // disable default error message
 
   // setup temp variables with invalid data so it can be detected later if
@@ -117,7 +117,7 @@ PAResult parse_args(const int argc, char *argv[], ServerConfig *out) {
   return OK;
 }
 
-void print_usage(const char *program_name) {
+void server_print_usage(const char *program_name) {
   fprintf(stderr,
           "Usage:\n"
           "  %s -t <threads> -p <file prefix> -c <max connections> [-h]\n"
@@ -130,7 +130,7 @@ void print_usage(const char *program_name) {
           program_name);
 }
 
-char *pa_result_to_string(const PAResult result) {
+char *server_pa_result_to_string(const SPAResult result) {
   switch (result) {
   case OK:
     return "success";

--- a/src/server/args.h
+++ b/src/server/args.h
@@ -26,8 +26,8 @@ typedef enum {
   MISSING_MAX_CONNECTIONS,
   MALFORMED_MAX_CONNECTIONS,
   MULTIPLE_MAX_CONNECTIONS,
-} PAResult;
+} SPAResult;
 
-PAResult parse_args(const int argc, char *argv[], ServerConfig *out);
-char *pa_result_to_string(PAResult result);
-void print_usage(const char *program_name);
+SPAResult server_parse_args(const int argc, char *argv[], ServerConfig *out);
+char *server_pa_result_to_string(SPAResult result);
+void server_print_usage(const char *program_name);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -4,16 +4,16 @@
 
 int main(int argc, char *argv[]) {
   ServerConfig config = {0};
-  PAResult result = parse_args(argc, argv, &config);
+  PAResult result = server_parse_args(argc, argv, &config);
 
   if (result == ONLY_HELP) {
-    print_usage(argv[0]);
+    server_print_usage(argv[0]);
     return 0;
   }
 
   if (result != OK) {
-    fprintf(stderr, "%s\n", pa_result_to_string(result));
-    print_usage(argv[0]);
+    fprintf(stderr, "%s\n", server_pa_result_to_string(result));
+    server_print_usage(argv[0]);
     return 1;
   }
 

--- a/tests/client_parse_args.c
+++ b/tests/client_parse_args.c
@@ -8,7 +8,7 @@
 
 typedef struct {
   char *argv_flat;
-  PAResult expected;
+  CPAResult expected;
 } TestCase;
 
 const TestCase cases[] = {
@@ -82,12 +82,12 @@ int main() {
     char **argv_case = split(test_case.argv_flat, &argc_case);
     ClientConfig __c;
 
-    const PAResult result = parse_args(argc_case, argv_case, &__c);
+    const CPAResult result = client_parse_args(argc_case, argv_case, &__c);
 
     if (result != test_case.expected) {
       printf("Test case %zu, wrong result\n\texpected: %s\n\tgot: %s\n", i,
-             pa_result_to_string(test_case.expected),
-             pa_result_to_string(result));
+             client_pa_result_to_string(test_case.expected),
+             client_pa_result_to_string(result));
       printf("argv:\n");
       for (int j = 0; j < argc_case; j++) {
         printf("\t%s\n", argv_case[j]);

--- a/tests/server_parse_args.c
+++ b/tests/server_parse_args.c
@@ -8,7 +8,7 @@
 
 typedef struct {
   char *argv_flat;
-  PAResult expected;
+  SPAResult expected;
 } TestCase;
 
 const TestCase cases[] = {
@@ -61,12 +61,12 @@ int main() {
     char **argv_case = split(test_case.argv_flat, &argc_case);
     ServerConfig __c;
 
-    const PAResult result = parse_args(argc_case, argv_case, &__c);
+    const SPAResult result = server_parse_args(argc_case, argv_case, &__c);
 
     if (result != test_case.expected) {
       printf("Test case %zu, wrong result\n\texpected: %s\n\tgot: %s\n", i,
-             pa_result_to_string(test_case.expected),
-             pa_result_to_string(result));
+             server_pa_result_to_string(test_case.expected),
+             server_pa_result_to_string(result));
       printf("argv:\n");
       for (int j = 0; j < argc_case; j++) {
         printf("\t%s\n", argv_case[j]);


### PR DESCRIPTION
The same name was an issue as multiple definitions are not allowed