### PR TITLE
Thread pool

### DIFF
--- a/src/common/thread_pool.c
+++ b/src/common/thread_pool.c
@@ -18,7 +18,7 @@ struct ThreadPool {
 
 typedef struct {
   ThreadPool *pool;
-  thread_func_t func;
+  task_func_t func;
   void *arg;
 } TPTask;
 
@@ -57,7 +57,7 @@ void thread_pool_free(ThreadPool *pool) {
   pool = NULL;
 }
 
-bool thread_pool_do(ThreadPool *pool, thread_func_t fn, void *arg) {
+bool thread_pool_do(ThreadPool *pool, task_func_t fn, void *arg) {
   // wait for a thread to close if the maximum number of threads is reached
   sem_wait(&pool->limiter);
 

--- a/src/common/thread_pool.c
+++ b/src/common/thread_pool.c
@@ -1,0 +1,111 @@
+#include "thread_pool.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct ThreadPool {
+  size_t max_threads;
+  sem_t limiter;
+  pthread_mutex_t join_lock;
+  size_t active_threads;
+  pthread_cond_t join_cond;
+};
+
+typedef struct {
+  ThreadPool *pool;
+  thread_func_t func;
+  void *arg;
+} TPoolWork;
+
+static void *task_wrapper(void *raw);
+
+ThreadPool *create_thread_pool(size_t max_threads) {
+  ThreadPool *tp = malloc(sizeof(ThreadPool));
+
+  tp->max_threads = max_threads;
+  sem_init(&tp->limiter, 0, max_threads);
+  pthread_mutex_init(&tp->join_lock, NULL);
+  pthread_cond_init(&tp->join_cond, NULL);
+  tp->active_threads = 0;
+
+  return tp;
+}
+
+void thread_pool_free(ThreadPool *pool) {
+  // ensure everythin is settled
+  thread_pool_join(pool);
+
+  sem_destroy(&pool->limiter);
+  pthread_mutex_destroy(&pool->join_lock);
+  pthread_cond_destroy(&pool->join_cond);
+
+  free(pool);
+  pool = NULL;
+}
+
+bool thread_pool_do(ThreadPool *pool, thread_func_t fn, void *arg) {
+  sem_wait(&pool->limiter);
+
+  TPoolWork *work = malloc(sizeof(TPoolWork));
+
+  // if work couldn't be allocated
+  if (!work) {
+    fprintf(stderr, "couldn't allocate memory for the requested task\n");
+    sem_post(&pool->limiter);
+    return false;
+  }
+
+  work->func = fn;
+  work->arg = arg;
+  work->pool = pool;
+
+  pthread_mutex_lock(&pool->join_lock);
+  pool->active_threads++;
+  pthread_mutex_unlock(&pool->join_lock);
+
+  pthread_t thread;
+  int res = pthread_create(&thread, NULL, task_wrapper, work);
+
+  // res == 0 -> ok
+  if (res == 0) {
+    pthread_detach(thread);
+    return true;
+  }
+
+  fprintf(stderr, "couldn't create thread for the requested task\n");
+  pthread_mutex_lock(&pool->join_lock);
+  pool->active_threads--;
+  pthread_mutex_unlock(&pool->join_lock);
+  sem_post(&pool->limiter);
+  free(work);
+  return false;
+}
+
+void thread_pool_join(ThreadPool *pool) {
+  pthread_mutex_lock(&pool->join_lock);
+  while (pool->active_threads > 0)
+    pthread_cond_wait(&pool->join_cond, &pool->join_lock);
+  pthread_mutex_unlock(&pool->join_lock);
+}
+
+static void *task_wrapper(void *raw) {
+  TPoolWork *work = raw;
+  ThreadPool *pool = work->pool;
+  work->func(work->arg);
+
+  pthread_mutex_lock(&pool->join_lock);
+
+  pool->active_threads--;
+  if (pool->active_threads == 0)
+    pthread_cond_signal(&pool->join_cond);
+
+  pthread_mutex_unlock(&pool->join_lock);
+  sem_post(&pool->limiter);
+
+  free(work);
+  return NULL; // needed for the signature but not used
+}

--- a/src/common/thread_pool.h
+++ b/src/common/thread_pool.h
@@ -2,13 +2,67 @@
 
 #include <stddef.h>
 
+/**
+ * @brief opaque struct needed for a thread pool
+ */
 typedef struct ThreadPool ThreadPool;
+
+/**
+ * @brief function signature for a task
+ *
+ * The function receives a void pointer and returns nothing
+ */
 typedef void (*thread_func_t)(void *arg);
 
+/**
+ * @brief creates a thread pool with the specified maximum number of threads
+ *
+ * Won't actually create the threads but the pool will be configured to use at
+ * max that number of threads at any moment
+ *
+ * @param max_threads the maximum number of concurrent threads
+ * @return the configured thread pool
+ */
 ThreadPool *create_thread_pool(size_t max_threads);
 
+/**
+ * @brief frees the memory allocated by the thread pool
+ *
+ * Frees only th memory of the `ThreadPool` object, not the memory that a task
+ * could allocate.
+ *
+ * For safety reasons a call to `thread_pool_join` is made.
+ *
+ * After this there is no need to call `free`.
+ *
+ * @param pool the thread pool
+ */
 void thread_pool_free(ThreadPool *pool);
 
+/**
+ * @brief submits a task to the thread pool
+ *
+ * If the pool has all the threads occupied it waits until at leas one finishes,
+ * meaning it's blocking.
+ *
+ * The arg has to be allocated on the heap.
+ *
+ * For the non blocking version use `thread_pool_try_do`.
+ *
+ * @param pool the thread pool
+ * @param fn the task
+ * @param arg the task argument
+ * @return true if the task was created successfully
+ */
 bool thread_pool_do(ThreadPool *pool, thread_func_t fn, void *arg);
 
+/**
+ * @brief waits until all tasks are completed
+ *
+ * Waits for all the task to be completed in a blocking way.
+ *
+ * If the tasks are already completed returns immediately.
+ *
+ * @param pool the thread pool
+ */
 void thread_pool_join(ThreadPool *pool);

--- a/src/common/thread_pool.h
+++ b/src/common/thread_pool.h
@@ -12,7 +12,7 @@ typedef struct ThreadPool ThreadPool;
  *
  * The function receives a void pointer and returns nothing
  */
-typedef void (*thread_func_t)(void *arg);
+typedef void (*task_func_t)(void *arg);
 
 /**
  * @brief creates a thread pool with the specified maximum number of threads
@@ -54,7 +54,7 @@ void thread_pool_free(ThreadPool *pool);
  * @param arg the task argument
  * @return true if the task was created successfully
  */
-bool thread_pool_do(ThreadPool *pool, thread_func_t fn, void *arg);
+bool thread_pool_do(ThreadPool *pool, task_func_t fn, void *arg);
 
 /**
  * @brief waits until all tasks are completed

--- a/src/common/thread_pool.h
+++ b/src/common/thread_pool.h
@@ -14,6 +14,13 @@ typedef struct ThreadPool ThreadPool;
  */
 typedef void (*task_func_t)(void *arg);
 
+typedef enum {
+  OK,              // task created and started
+  POOL_BUSY,       // thread pool has not free threads
+  FAILED_CREATION, // failed to allocate memory for the task
+  FAILED_START     // failed to start the task
+} TPTaskResult;
+
 /**
  * @brief creates a thread pool with the specified maximum number of threads
  *
@@ -52,9 +59,24 @@ void thread_pool_free(ThreadPool *pool);
  * @param pool the thread pool
  * @param fn the task
  * @param arg the task argument
- * @return true if the task was created successfully
+ * @return `OK` if successful or an error status
  */
-bool thread_pool_do(ThreadPool *pool, task_func_t fn, void *arg);
+TPTaskResult thread_pool_do(ThreadPool *pool, task_func_t fn, void *arg);
+
+/**
+ * @brief submits a task to the thread pool in a non-blocking way
+ *
+ * Same as `thread_pool_do` but exits early if the task could not be created as
+ * the pool is completely used
+ *
+ * The non-blocking part refers to the creation of the task
+ *
+ * @param pool the thread pool
+ * @param fn the task
+ * @param arg the task argument
+ * @return `OK` if successful or an error status
+ */
+TPTaskResult thread_pool_try_do(ThreadPool *pool, task_func_t fn, void *arg);
 
 /**
  * @brief waits until all tasks are completed

--- a/src/common/thread_pool.h
+++ b/src/common/thread_pool.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stddef.h>
+
+typedef struct ThreadPool ThreadPool;
+typedef void (*thread_func_t)(void *arg);
+
+ThreadPool *create_thread_pool(size_t max_threads);
+
+void thread_pool_free(ThreadPool *pool);
+
+bool thread_pool_do(ThreadPool *pool, thread_func_t fn, void *arg);
+
+void thread_pool_join(ThreadPool *pool);

--- a/tests/thread_pool.c
+++ b/tests/thread_pool.c
@@ -1,0 +1,55 @@
+#include "common/thread_pool.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FROM 0
+#define TO 100
+
+int counter = 0;
+pthread_mutex_t counter_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void task(int i);
+int sum(const int from, const int to);
+
+void task_wrapper(void *i_ptr) {
+  int i = *(int *)i_ptr;
+  free(i_ptr);
+  pthread_mutex_lock(&counter_lock);
+  task(i);
+  pthread_mutex_unlock(&counter_lock);
+}
+
+int main() {
+  int expected = sum(FROM, TO);
+  ThreadPool *tp = create_thread_pool(5);
+
+  for (int i = FROM; i < TO; i++) {
+    int *arg = malloc(sizeof(int));
+    *arg = i;
+    thread_pool_do(tp, task_wrapper, arg);
+  }
+
+  thread_pool_join(tp);
+
+  printf("result: %d\nexpected: %d\n", counter, expected);
+
+  thread_pool_free(tp);
+
+  if (counter != expected)
+    return 1;
+
+  return 0;
+}
+
+void task(int i) { counter += i; }
+int sum(const int from, const int to) {
+  int n = 0;
+
+  for (int i = from; i < to; i++) {
+    n += i;
+  }
+
+  return n;
+}

--- a/tests/thread_pool_nb.c
+++ b/tests/thread_pool_nb.c
@@ -1,0 +1,35 @@
+#include "common/thread_pool.h"
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#define MAX_THREADS 5
+
+// simulates a task that is longer enough for the pool to be full and fail to
+// start a task in the for loop
+void dummy_task() { sleep(1); }
+
+void dummy_task_wrapper(void *nothing) {
+  dummy_task();
+
+  // just to remove unused warning
+  free(nothing);
+}
+
+int main() {
+  ThreadPool *tp = create_thread_pool(MAX_THREADS);
+
+  for (int i = 0; i < MAX_THREADS + 1; i++) {
+    switch (thread_pool_try_do(tp, dummy_task_wrapper, NULL)) {
+    case POOL_BUSY:
+      thread_pool_free(tp);
+      return 0;
+
+    default:
+      break;
+    }
+  }
+
+  thread_pool_free(tp);
+  return 1;
+}


### PR DESCRIPTION
# Aggiunta API per creare un pool di thread 

Permette di specificare quanti thread si vogliono creare e poi si richiede di fare del lavoro chiamando una funzione che accetta un singolo puntatore void, siccome C non ha tipi generici o simili

Un esempio già c'è nei test ma ne metto un'altro qui

```c
void some_func(CustomStruct some_data){
  // del lavoro
}

// wrapper in modo tale da renderlo compatibile con l'API
void some_func_wrapper(void* some_data_ptr){
  CustomStruct *some_data = (CustomStruct *)(ptr);

  // chiamo la funzione che fa il lavoro
  some_func(*some_data);

  // l'API non fa free quindi o qui o in `some_func` va fatto free
  // In questo esempio ha senso farlo qui
  free(some_data);
}

#define MAX_THREADS 5
int main() {
  ThreadPool* pool = create_thread_pool(MAX_THREADS);

  for (int i = 0; i < 100; i++) {
    // IMPORTANTE: il dato, qualunque tipo sia,
    // DEVE essere allocato in heap
    CustomStruct* data = malloc(sizeof(CustomStruct));

    // valorizzazione

    // richiesta al pool di eseguire del lavoro.
    // Se il pool ha tutti i thread occupati aspetterà qui.
    // Significa quindi che il lavoro DEVE terminare altrimenti
    // non si andrà mai avanti
    thread_pool_do(pool, some_func_wrapper, data);

    // per la versione non bloccante si può usare la seguente
    // sarebbe importante in entrambi i casi leggere il valore di ritorno
    // per capire se è andato a buon fine o meno, viene omesso qui 
    // per semplicità
    thread_pool_try_do(pool, some_func_wrapper, data);
  }

  // assicura che tutti i thread abbiano terminato il lavoro 
  // dopo questa riga, aspetta finchè non è così.
  // Non è richiesto però comunque è bene farlo
  thread_pool_join(pool);

  // altro lavoro

  // libero il pool, non basta il `free` normale ma 
  // libera comunque tutta la memoria occupata dal pool
  // quindi non serve fare un free dopo a questo
  thread_pool_free(pool);

  return 0;
}

```

## Considerazioni

- Anche se sembra molto restrittiva in realtà non è che si possa fare di tanto meglio senza introdurre delle macro ma poi diventa troppo complicato
- Come già scritto `thread_pool_do` se non ha thread disponibili rimane bloccato (c'è un semaforo) finché non si libera almeno un thread
- Non è type safe siccome il wrapper (o qualsiasi funzione si passa al `thread_pool_do`) accetta un puntatore a void quindi va bene qualsiasi cosa, se si passa la cosa sbagliata poi il comportamento è indefinito
- Viene suggerito il pattern con funzione che fa il lavoro "safe" e poi il wrapper che gestisce il layer di compatibilità ma nulla vieta che sia fatto in una sola funzione
- Sempre come scritto prima è necessario che la funzione accetti 1 solo argomento, se non serve nulla si può passare NULL e se serve di più si può fare uno struct