### PR TITLE
block signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ include_directories(src)
 # for signals
 add_compile_definitions(_POSIX_C_SOURCE=200809L)
 
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  message(FATAL_ERROR "Error: the project is Linux only")
+endif()
+
 file(GLOB_RECURSE COMMON_SRC ${CMAKE_SOURCE_DIR}/src/common/*.c)
 file(GLOB_RECURSE CLIENT_SRC ${CMAKE_SOURCE_DIR}/src/client/*.c)
 file(GLOB_RECURSE SERVER_SRC ${CMAKE_SOURCE_DIR}/src/server/*.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ add_compile_options(-Wall -Wextra)
 # for headers 
 include_directories(src)
 
+# for signals
+add_compile_definitions(_POSIX_C_SOURCE=200809L)
+
 file(GLOB_RECURSE COMMON_SRC ${CMAKE_SOURCE_DIR}/src/common/*.c)
 file(GLOB_RECURSE CLIENT_SRC ${CMAKE_SOURCE_DIR}/src/client/*.c)
 file(GLOB_RECURSE SERVER_SRC ${CMAKE_SOURCE_DIR}/src/server/*.c)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## Server
 
 ```sh
-gcc -std=c2x src/server/*.c src/common/*.c -Isrc -o server
+gcc -std=c2x src/server/*.c src/common/*.c -Isrc -D_POSIX_C_SOURCE=200809L -o server
 ```
 
 ## Client
 
 ```sh
-gcc -std=c2x src/client/*.c src/common/*.c -Isrc -o client
+gcc -std=c2x src/client/*.c src/common/*.c -Isrc -D_POSIX_C_SOURCE=200809L -o client
 ```

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
   // Set signal handlers to handle signals during encryption
   if (!block_signals(&new_mask, &old_mask)) {
     fprintf(stderr, "Couldn't block signals\n");
-    return 0;
+    return 1;
   }
 
   // Create socket

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -1,5 +1,6 @@
 #include "args.h"
 #include "common/message.h"
+#include "common/signals.h"
 #include "common/socket.h"
 #include "encryption.h"
 #include "socket.h"
@@ -8,9 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-static bool block_signals(sigset_t *new_mask, sigset_t *old_mask);
-static bool unblock_signals(sigset_t *old_mask);
 
 int main(int argc, char *argv[]) {
   ClientConfig config = {0};
@@ -115,25 +113,4 @@ int main(int argc, char *argv[]) {
   close_socket(client_socket);
   free(client_socket);
   return flag;
-}
-
-static bool block_signals(sigset_t *new_mask, sigset_t *old_mask) {
-  sigemptyset(new_mask);
-  sigaddset(new_mask, SIGINT);
-  sigaddset(new_mask, SIGALRM);
-  sigaddset(new_mask, SIGUSR1);
-  sigaddset(new_mask, SIGUSR2);
-  sigaddset(new_mask, SIGTERM);
-
-  if (sigprocmask(SIG_BLOCK, new_mask, old_mask) < 0)
-    return false;
-
-  return true;
-}
-static bool unblock_signals(sigset_t *old_mask) {
-  if (sigprocmask(SIG_SETMASK, old_mask, NULL) < 0) {
-    return false;
-  }
-
-  return true;
 }

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -5,7 +5,6 @@
 #include "encryption.h"
 #include "socket.h"
 
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/client/encryption.c
+++ b/src/client/encryption.c
@@ -28,17 +28,8 @@ void xor_encrypt_block(void *arg) {
   free(task);
 }
 
-static void signal_handler(int sig) { printf("Ricevuto segnale %d\n", sig); }
-
 char *encrypt_file(const char *filename, uint64_t key, 
                    size_t *in_len, size_t *out_len, size_t threads) {
-  // blocca solo i segnali specificati
-  signal(SIGINT, signal_handler);
-  signal(SIGALRM, signal_handler);
-  signal(SIGUSR1, signal_handler);
-  signal(SIGUSR2, signal_handler);
-  signal(SIGTERM, signal_handler);
-
   char *data = get_data(filename, in_len);
   if (!data) {
     return NULL;
@@ -85,13 +76,6 @@ char *encrypt_file(const char *filename, uint64_t key,
   thread_pool_free(pool);
 
   free(padded_data);
-
-  // Ripristinare handler originali
-  signal(SIGINT, SIG_DFL);
-  signal(SIGALRM, SIG_DFL);
-  signal(SIGUSR1, SIG_DFL);
-  signal(SIGUSR2, SIG_DFL);
-  signal(SIGTERM, SIG_DFL);
   
   return cipherdata;
 }

--- a/src/common/signals.c
+++ b/src/common/signals.c
@@ -1,0 +1,25 @@
+#include "signals.h"
+
+#include <string.h>
+
+bool block_signals(sigset_t *new_mask, sigset_t *old_mask) {
+  sigemptyset(new_mask);
+  sigaddset(new_mask, SIGINT);
+  sigaddset(new_mask, SIGALRM);
+  sigaddset(new_mask, SIGUSR1);
+  sigaddset(new_mask, SIGUSR2);
+  sigaddset(new_mask, SIGTERM);
+
+  if (sigprocmask(SIG_BLOCK, new_mask, old_mask) < 0)
+    return false;
+
+  return true;
+}
+
+bool unblock_signals(sigset_t *old_mask) {
+  if (sigprocmask(SIG_SETMASK, old_mask, NULL) < 0) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/common/signals.h
+++ b/src/common/signals.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <signal.h>
+
+bool block_signals(sigset_t *new_mask, sigset_t *old_mask);
+bool unblock_signals(sigset_t *old_mask);

--- a/src/server/decrypt.c
+++ b/src/server/decrypt.c
@@ -36,13 +36,6 @@ static void signal_handler(int sig) { printf("Ricevuto segnale %d\n", sig); }
 
 char *decrypt_message(char *cipherdata, size_t padded_len, uint64_t key,
                       size_t n_threads) {
-  // blocca solo i segnali specificati
-  signal(SIGINT, signal_handler);
-  signal(SIGALRM, signal_handler);
-  signal(SIGUSR1, signal_handler);
-  signal(SIGUSR2, signal_handler);
-  signal(SIGTERM, signal_handler);
-
   char *output = malloc(padded_len);
 
   size_t num_blocks = padded_len*8 / BLOCK_SIZE;
@@ -66,13 +59,6 @@ char *decrypt_message(char *cipherdata, size_t padded_len, uint64_t key,
 
   thread_pool_join(pool);
   thread_pool_free(pool);
-  
-  // Ripristinare handler originali
-  signal(SIGINT, SIG_DFL);
-  signal(SIGALRM, SIG_DFL);
-  signal(SIGUSR1, SIG_DFL);
-  signal(SIGUSR2, SIG_DFL);
-  signal(SIGTERM, SIG_DFL);
 
   return output;
 }

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -5,6 +5,7 @@
 #include "socket.h"
 
 #include <assert.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -20,7 +21,16 @@ typedef struct {
 
 void generate_filename(char *buffer, size_t buffer_size, const char *prefix);
 
+static void signal_handler(int sig) { printf("Ricevuto segnale %d\n", sig); }
+
 void handle_client(ClientHandle *handle) {
+  // Block only the specified signals
+  signal(SIGINT, signal_handler);
+  signal(SIGALRM, signal_handler);
+  signal(SIGUSR1, signal_handler);
+  signal(SIGUSR2, signal_handler);
+  signal(SIGTERM, signal_handler);
+
   Message *message = handle->message;
 
   char *decrypted_data =
@@ -49,6 +59,13 @@ void handle_client(ClientHandle *handle) {
 
   fclose(fout);
   free(decrypted_data);
+
+  // Reset the signal handlers to default
+  signal(SIGINT, SIG_DFL);
+  signal(SIGALRM, SIG_DFL);
+  signal(SIGUSR1, SIG_DFL);
+  signal(SIGUSR2, SIG_DFL);
+  signal(SIGTERM, SIG_DFL);
 
   printf("Saved in %s\n", fname);
 


### PR DESCRIPTION
> Il processo client, quando effettua le operazioni di cifratura e di invio non deve essere interrotto da (SIGINT, SIGALRM, SIGUSR1, SIGUSR2, SIGTERM).
> Un thread del processo server che sta decifrando un messaggio C e un thread del processo server che sta scrivendo il testo decifrato su disco non devono essere interrotto dai segnali (SIGINT, SIGALRM, SIGUSR1, SIGUSR2, SIGTERM).

Non so se preferite così o metto i signal() dentro le funzioni.
Comunque ho visto su slide che signal() è deprecato, volevo fare con sigprocmask() ma ho problemi di include, funzionava da altre parti ma qui no, quindi ho lasciato signal(). 
Non so se potete provare con sigprocmask().